### PR TITLE
feat: integrate systemd service and module improvements from thomas-bp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,13 +91,18 @@
             fileSystems."/" = {
               device = "none";
               fsType = "tmpfs";
-              options = [
-                "defaults"
-                "mode=755"
-              ];
+              options = ["defaults" "mode=755"];
             };
             users.users.root.initialPassword = "password";
+            users.users.test = {
+              isNormalUser = true;
+              initialPassword = "password";
+              group = "users";
+            };
             programs.companion.enable = true;
+            services.openssh.enable = true;
+            services.openssh.settings.PermitRootLogin = "yes";
+            networking.firewall.allowedTCPPorts = [22];
           }
         ];
       };

--- a/module.nix
+++ b/module.nix
@@ -10,9 +10,50 @@
       description = "Which companion package to install.";
     };
     enable = lib.mkEnableOption "Add Bitfocus Companion to installed packages.";
+    autoStart = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to start Bitfocus Companion automatically at boot.";
+    };
+    user = lib.mkOption {
+      type = lib.types.str;
+      #default = "companion";
+      description = "User under which the Companion service will run.";
+    };
+    group = lib.mkOption {
+      type = lib.types.str;
+      #default = "users";
+      description = "Group under which the Companion service will run.";
+    };
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to open firewall ports for Companion.";
+    };
   };
   cfg = config.programs.companion;
 in {
   inherit options;
-  config = lib.mkIf cfg.enable {environment.systemPackages = [cfg.package];};
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+    systemd.services.companion = {
+      description = "Bitfocus Companion";
+      wantedBy = lib.mkIf cfg.autoStart ["multi-user.target"];
+      after = ["network.target"];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/companion";
+        Restart = "on-failure";
+        RestartSec = "10s";
+        NoNewPrivileges = true;
+        ProtectSystem = "full";
+        ProtectHome = lib.mkDefault false;
+      };
+    };
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [8000];
+    };
+  };
 }

--- a/module.nix
+++ b/module.nix
@@ -10,33 +10,32 @@
       description = "Which companion package to install.";
     };
     enable = lib.mkEnableOption "Add Bitfocus Companion to installed packages.";
+    runAsService = lib.mkEnableOption "Run Companion as a systemd service instead of just installing the package.";
     autoStart = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Whether to start Bitfocus Companion automatically at boot.";
+      description = "Whether to start Bitfocus Companion automatically at boot (only used when runAsService is enabled).";
     };
     user = lib.mkOption {
       type = lib.types.str;
-      #default = "companion";
-      description = "User under which the Companion service will run.";
+      description = "User under which the Companion service will run (required when runAsService is enabled).";
     };
     group = lib.mkOption {
       type = lib.types.str;
-      #default = "users";
-      description = "Group under which the Companion service will run.";
+      description = "Group under which the Companion service will run (required when runAsService is enabled).";
     };
     openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Whether to open firewall ports for Companion.";
+      description = "Whether to open firewall ports for Companion (only used when runAsService is enabled).";
     };
   };
   cfg = config.programs.companion;
 in {
   inherit options;
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [cfg.package];
-    systemd.services.companion = {
+    environment.systemPackages = lib.mkIf (!cfg.runAsService) [cfg.package];
+    systemd.services.companion = lib.mkIf cfg.runAsService {
       description = "Bitfocus Companion";
       wantedBy = lib.mkIf cfg.autoStart ["multi-user.target"];
       after = ["network.target"];
@@ -52,7 +51,7 @@ in {
         ProtectHome = lib.mkDefault false;
       };
     };
-    networking.firewall = lib.mkIf cfg.openFirewall {
+    networking.firewall = lib.mkIf (cfg.runAsService && cfg.openFirewall) {
       allowedTCPPorts = [8000];
     };
   };


### PR DESCRIPTION
- Add systemd service configuration for Companion daemon
- Add autoStart, user, group, and openFirewall module options
- Improve test VM configuration with test user and SSH access
- Remove user/group defaults to defer security decisions to downstream
- Gate service behind option for now

Based on improvements from thomas-bp's fork:
https://github.com/thomas-bp/bitfocus-companion-flake