### PR TITLE
Fix executable path for companion binary

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -43,7 +43,7 @@ in {
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = "${cfg.package}/bin/companion";
+        ExecStart = "${cfg.package}/bin/bitfocus-companion";
         Restart = "on-failure";
         RestartSec = "10s";
         NoNewPrivileges = true;


### PR DESCRIPTION
Systemd service uses the wrong executable name. 
Packaged executable name: 
`$ /nix/store/svfid8a4m6lkyv5r15ng77rjvhijma6f-bitfocus-companion-4.1.4/bin/`  
`bitfocus-companion`

currently called is just `companion`.  Build and service fine on test fork.